### PR TITLE
Update Example Based on loadCSS Best Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The loadCSS and onloadCSS files will be added to the asset pipeline and availabl
 Here's a quick example of what you would drop in your application's layout (usually `app/views/layouts/application.html.erb`):
 
 ```html
-<link rel="preload" href="<%= stylesheet_path('application') %>" as="style" onload="this.rel='stylesheet'">
+<link rel="preload" href="<%= stylesheet_path('application') %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="<%= stylesheet_path('application') %>"></noscript>
 ```
 


### PR DESCRIPTION
`this.onload=null` is a necessary addition to the `<link>` tag in order to prevent failures in IE11 and Edge, per https://github.com/filamentgroup/loadCSS/issues/262